### PR TITLE
Update closure-compiler to version v20220803, so it doesn't collide w…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ task createClasspathManifest {
 
 dependencies {
     implementation gradleApi()
-    implementation('com.google.javascript:closure-compiler:v20160208') {
+    implementation('com.google.javascript:closure-compiler:v20220803') {
         exclude module: 'junit'
     }
     implementation('io.jdev.html2js:html2js:0.1') {
@@ -53,7 +53,7 @@ dependencies {
         exclude module: 'groovy-all'
     }
     testImplementation 'commons-lang:commons-lang:2.6'
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 compileGroovy {

--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -25,13 +25,13 @@ class JsMinifier {
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
         WarningLevel level = WarningLevel.valueOf(warningLevel)
         level.setOptionsForWarningLevel(options)
-        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions());
+        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions().environment);
         if (externsFiles.size()) {
-            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it) })
+            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it.toString()) })
         }
         List<SourceFile> inputs = new ArrayList<SourceFile>()
         inputFiles.each { inputFile -> 
-          inputs.add(SourceFile.fromFile(inputFile))
+          inputs.add(SourceFile.fromFile(inputFile.toString()))
         }
         Result result = compiler.compile(externs, inputs, options)
         if (result.success) {


### PR DESCRIPTION
…ith other plugins.
Also updating junit to latest 4.x version available.

Please merge and push version update to gradle plugins repository, so it doesn't depend on old guava version making it incompatible with latest palantir.git-version plugin.

All tests PASSED.

Thanks